### PR TITLE
Add new columns 'CertSerial' and 'PeerAddress'

### DIFF
--- a/.devcontainer/initdb.d/01_create_db.sql
+++ b/.devcontainer/initdb.d/01_create_db.sql
@@ -11,6 +11,7 @@ CREATE TABLE Certificates (
     Valid_To DATE,
     Last_Check DATETIME,
     CertSerial TEXT,
+    PeerAddress TEXT,
     PRIMARY KEY (ID),
     UNIQUE (Domain)
 );

--- a/.devcontainer/initdb.d/01_create_db.sql
+++ b/.devcontainer/initdb.d/01_create_db.sql
@@ -10,6 +10,7 @@ CREATE TABLE Certificates (
     Valid_From DATE,
     Valid_To DATE,
     Last_Check DATETIME,
+    CertSerial TEXT,
     PRIMARY KEY (ID),
     UNIQUE (Domain)
 );

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Run pytest in docker
         run: |
           docker run --rm --entrypoint=python ${{ steps.meta.outputs.tags }} -m pytest
+          docker run --rm --entrypoint=python ${{ steps.meta.outputs.tags }} -m pytest migration_tests
 
       - name: Build and push Docker image (Scanner)
         id: build-and-push

--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -21,6 +21,7 @@ COPY \
 
 # Add test codes
 COPY ./tests /app/tests
+COPY ./migration_tests /app/migration_tests
 
 # Set working directory
 WORKDIR /app

--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -16,6 +16,7 @@ COPY \
   push_slackbot.py \
   command.py \
   command_util.py \
+  ssl_patch.py \
   __main__.py \
   /app/
 

--- a/scanner/command.py
+++ b/scanner/command.py
@@ -212,7 +212,7 @@ def get_table() -> dataset.Table:
     if not db.has_table('Certificates'):
         raise CommandException.TableNotFound()
     table: dataset.Table = db.get_table("Certificates")
-    if not table.has_column('CertSerial'):
+    if not all([table.has_column(c) for c in ['CertSerial', 'PeerAddress']]):
         warning("The table format is not latest versions. Please reform with 'init' command.")
     return table
 
@@ -257,6 +257,7 @@ def convert_to_output(row: dict, now: date) -> dict:
     ]
     extra_keys = [
         'CertSerial',
+        'PeerAddress',
     ]
     if row['Valid_To'] is None:
         remain = None

--- a/scanner/command.py
+++ b/scanner/command.py
@@ -251,11 +251,16 @@ def convert_to_output(row: dict, now: date) -> dict:
         'Valid_To',
         'Last_Check'
     ]
+    extra_keys = [
+        'CertSerial',
+    ]
     if row['Valid_To'] is None:
         remain = None
     else:
         remain = (row['Valid_To'] - now).days
     data = {k: row[k] for k in keys}
+    for k in extra_keys:
+        data[k] = data.get(k)
     data['Remaining_Days'] = remain
     data['Remaining_Base'] = now
 

--- a/scanner/command.py
+++ b/scanner/command.py
@@ -1,3 +1,4 @@
+from logging import warning
 import validators
 import json
 import dataset
@@ -210,7 +211,10 @@ def get_table() -> dataset.Table:
     from db import db
     if not db.has_table('Certificates'):
         raise CommandException.TableNotFound()
-    return db.get_table("Certificates")
+    table: dataset.Table = db.get_table("Certificates")
+    if not table.has_column('CertSerial'):
+        warning("The table format is not latest versions. Please reform with 'init' command.")
+    return table
 
 
 def assert_domain_format(domain: str):

--- a/scanner/controler.py
+++ b/scanner/controler.py
@@ -48,7 +48,7 @@ def get_list(n, id):
     return (chunk)
 
 
-def update(domain, subject, issuer, sig_algo, start_date, expiry_date, checkdate):
+def update(domain, subject, issuer, sig_algo, start_date, expiry_date, checkdate, cert_serial):
     data = dict(
         Domain=domain,
         Subject=subject,
@@ -57,6 +57,7 @@ def update(domain, subject, issuer, sig_algo, start_date, expiry_date, checkdate
         Valid_From=start_date,
         Valid_To=expiry_date,
         Last_Check=checkdate,
+        CertSerial=cert_serial,
     )
     with db as tx:
         certificates = tx["Certificates"]

--- a/scanner/controler.py
+++ b/scanner/controler.py
@@ -48,7 +48,7 @@ def get_list(n, id):
     return (chunk)
 
 
-def update(domain, subject, issuer, sig_algo, start_date, expiry_date, checkdate, cert_serial):
+def update(domain, subject, issuer, sig_algo, start_date, expiry_date, checkdate, cert_serial, peer_address):
     data = dict(
         Domain=domain,
         Subject=subject,
@@ -58,6 +58,7 @@ def update(domain, subject, issuer, sig_algo, start_date, expiry_date, checkdate
         Valid_To=expiry_date,
         Last_Check=checkdate,
         CertSerial=cert_serial,
+        PeerAddress=peer_address,
     )
     with db as tx:
         certificates = tx["Certificates"]

--- a/scanner/db.py
+++ b/scanner/db.py
@@ -96,6 +96,7 @@ def alter_certificates_table(table: dataset.Table) -> dataset.Table:
         ("Valid_From", dict(type=db.types.date)),
         ("Valid_To", dict(type=db.types.date)),
         ("Last_Check", dict(type=db.types.datetime)),
+        ("CertSerial", dict(type=db.types.text)),
     ]
     for column in columns:
         if not table.has_column(column[0]):

--- a/scanner/db.py
+++ b/scanner/db.py
@@ -97,6 +97,7 @@ def alter_certificates_table(table: dataset.Table) -> dataset.Table:
         ("Valid_To", dict(type=db.types.date)),
         ("Last_Check", dict(type=db.types.datetime)),
         ("CertSerial", dict(type=db.types.text)),
+        ("PeerAddress", dict(type=db.types.text)),
     ]
     for column in columns:
         if not table.has_column(column[0]):

--- a/scanner/db.py
+++ b/scanner/db.py
@@ -67,7 +67,12 @@ def create_certificates_table(drop_exists=False) -> dataset.Table:
     """
     if db.has_table("Certificates") and drop_exists:
         db.get_table("Certificates").drop()
-    table: dataset.Table = db.create_table("Certificates", primary_id="ID")
+    if db.has_table("Certificates"):
+        table: dataset.Table = db.get_table("Certificates")
+        if not table.has_column("ID"):
+            raise Exception("Unexpected formatted table 'Certificates' in the database.")
+    else:
+        table: dataset.Table = db.create_table("Certificates", primary_id="ID")
     alter_certificates_table(table)
     return table
 

--- a/scanner/db.py
+++ b/scanner/db.py
@@ -68,13 +68,33 @@ def create_certificates_table(drop_exists=False) -> dataset.Table:
     if db.has_table("Certificates") and drop_exists:
         db.get_table("Certificates").drop()
     table: dataset.Table = db.create_table("Certificates", primary_id="ID")
-    table.create_column("Domain", type=db.types.string(256), unique=True)
-    table.create_column("Subject", type=db.types.text)
-    table.create_column("Issuer", type=db.types.text)
-    table.create_column("SigAlgorithm", type=db.types.text)
-    table.create_column("Valid_From", type=db.types.date)
-    table.create_column("Valid_To", type=db.types.date)
-    table.create_column("Last_Check", type=db.types.datetime)
+    alter_certificates_table(table)
+    return table
+
+
+def alter_certificates_table(table: dataset.Table) -> dataset.Table:
+    """
+    Migrate the columns on 'Certificates' table.
+
+    Args:
+        table (dataset.Table):
+            An instance to communicate with the table.
+
+    Returns:
+        dataset.Table: An instance to communicate with the table.
+    """
+    columns = [
+        ("Domain", dict(type=db.types.string(256), unique=True)),
+        ("Subject", dict(type=db.types.text)),
+        ("Issuer", dict(type=db.types.text)),
+        ("SigAlgorithm", dict(type=db.types.text)),
+        ("Valid_From", dict(type=db.types.date)),
+        ("Valid_To", dict(type=db.types.date)),
+        ("Last_Check", dict(type=db.types.datetime)),
+    ]
+    for column in columns:
+        if not table.has_column(column[0]):
+            table.create_column(column[0], **(column[1]))
     return table
 
 

--- a/scanner/migration_tests/extra/db_v1.py
+++ b/scanner/migration_tests/extra/db_v1.py
@@ -1,0 +1,112 @@
+"""
+This module provide a "dataset.Database" instance to communicate with a database.
+The "dataset" library API documentation can be viewed at the following URL.
+
+https://dataset.readthedocs.io/en/latest/api.html
+
+    # The target database is determined by the "DATABASE" environment variable
+    # when this module is loaded.
+    from db import db
+
+    # Get a "dataset.Table" instance to communicate with "Certificates" table.
+    table = db.get_table("Certificates")
+    # Count entries in "Certificates" table.
+    table.count()
+
+"DATABASE" or "MYSQL_PASSWORD" environment variables must be set to use this module.
+
+    # Use SQLite3 database
+    export DATABASE="sqlite:///db.sqlite"
+
+    # Use MySQL (MariaDB) database.
+    export DATABASE="mysql://user:password@host:port/dbname"
+
+"""
+
+import os
+import dataset
+
+
+__all__ = ['db', 'create_certificates_table', 'populate_certificates_table']
+
+
+def _load_connection_string() -> str:
+    """
+    Build a database connection string from environment variables.
+    The supported databases are depend on "dataset" library.
+
+    Returns:
+        str: A database connection string, like "schema://user:password@dbhost/dbname"
+    """
+    connection_string = os.environ.get('DATABASE')
+    if connection_string is None:
+        mysql_host = os.environ.get('MYSQL_HOST', 'DB')
+        mysql_user = os.environ.get('MYSQL_USER', 'root')
+        mysql_database = os.environ.get('MYSQL_DATABASE', 'Certificates')
+        mysql_password = os.environ.get('MYSQL_PASSWORD', os.environ.get('MYSQL_ROOT_PASSWORD'))
+        if mysql_password is None:
+            connection_string = f"mysql://{mysql_user}@{mysql_host}/{mysql_database}"
+        else:
+            connection_string = f"mysql://{mysql_user}:{mysql_password}@{mysql_host}/{mysql_database}"
+    return connection_string
+
+
+def create_certificates_table(drop_exists=False) -> dataset.Table:
+    """
+    Create 'Certificates' table on the database.
+
+    The target database is determined at the time this module is loaded into the application.
+
+    Args:
+        drop_exists (bool, optional):
+            If True, the existing table will be dropped and recreated.
+            Defaults to False.
+
+    Returns:
+        dataset.Table: An instance to communicate with the table.
+    """
+    if db.has_table("Certificates") and drop_exists:
+        db.get_table("Certificates").drop()
+    table: dataset.Table = db.create_table("Certificates", primary_id="ID")
+    alter_certificates_table(table)
+    return table
+
+
+def alter_certificates_table(table: dataset.Table) -> dataset.Table:
+    """
+    Migrate the columns on 'Certificates' table.
+
+    Args:
+        table (dataset.Table):
+            An instance to communicate with the table.
+
+    Returns:
+        dataset.Table: An instance to communicate with the table.
+    """
+    columns = [
+        ("Domain", dict(type=db.types.string(256), unique=True)),
+        ("Subject", dict(type=db.types.text)),
+        ("Issuer", dict(type=db.types.text)),
+        ("SigAlgorithm", dict(type=db.types.text)),
+        ("Valid_From", dict(type=db.types.date)),
+        ("Valid_To", dict(type=db.types.date)),
+        ("Last_Check", dict(type=db.types.datetime)),
+    ]
+    for column in columns:
+        if not table.has_column(column[0]):
+            table.create_column(column[0], **(column[1]))
+    return table
+
+
+def populate_certificates_table(domains: list):
+    """
+    Add entries into "Certificates" table.
+
+    Args:
+        domains (list): A list of "domain" strings to be inserted.
+    """
+    table = db.get_table("Certificates")
+    table.insert_many([dict(Domain=d) for d in domains])
+
+
+db = dataset.connect(_load_connection_string())

--- a/scanner/migration_tests/migration_test.py
+++ b/scanner/migration_tests/migration_test.py
@@ -1,0 +1,136 @@
+import os
+import pytest
+import click
+from datetime import datetime, date
+from click.testing import CliRunner, Result
+
+# Overwrite database connecting options for tests
+os.environ["DATABASE"] = "sqlite:///test.sqlite"
+# Supress warnings about SQLAlchemy
+os.environ["SQLALCHEMY_SILENCE_UBER_WARNING"] = "1"
+import dataset  # noqa: E402
+
+
+@pytest.fixture(scope='module')
+def db_v1():
+    from migration_tests.extra.db_v1 import db as db_v1
+    return db_v1
+
+
+@pytest.fixture(scope='module')
+def table_v1(db_v1: dataset.Table) -> dataset.Table:
+    """ Create 'Certificates' table in previous version on the database
+    """
+    from migration_tests.extra import db_v1
+    table = db_v1.create_certificates_table(drop_exists=True)
+    db_v1.populate_certificates_table([
+        "github.com",
+        "slack.com",
+        "google.com",
+        "yahoo.com",
+    ])
+    data = [
+        "github.com",
+        "www.github.com",
+        "Test CA",
+        "RSA 256",
+        date.fromisoformat("2023-01-01"),
+        date.fromisoformat("2023-01-02"),
+        datetime.fromisoformat("2023-01-03 00:00:00"),
+    ]
+    inserted = update_v1(db_v1.db, *data)
+    after = table.find_one(Domain="github.com")
+    assert [v for v in inserted.values()] == [*data]
+    assert [v for v in after.values()] == [1, *data]
+    return table
+
+
+@pytest.fixture(scope='module')
+def db(table_v1: dataset.Table):
+    from db import db
+    return db
+
+
+@pytest.fixture(scope='module')
+def table(table_v1: dataset.Table):
+    print(table_v1.columns)
+    from db import create_certificates_table
+    table = create_certificates_table(drop_exists=False)
+
+    assert table.count() == 4
+
+    check_data = dict(
+        ID=1,
+        Domain="github.com",
+        Subject="www.github.com",
+        Issuer="Test CA",
+        SigAlgorithm="RSA 256",
+        Valid_From=date.fromisoformat("2023-01-01"),
+        Valid_To=date.fromisoformat("2023-01-02"),
+        Last_Check=datetime.fromisoformat("2023-01-03 00:00:00"),
+        CertSerial=None,
+    )
+    migrated_data = table.find_one(Domain="github.com")
+    assert all([v == migrated_data[k] for k, v in check_data.items()])
+    return table
+
+
+@pytest.fixture(name='cli')
+def cli(table: dataset.Table) -> click.Group:
+    from command import cli as cli_application
+    return cli_application
+
+
+def test_update_s1(table: dataset.Table):
+    from controler import update  # noqa:E402
+
+    data = dict(
+        Domain="slack.com",
+        Subject="www.slack.com",
+        Issuer="Test CA",
+        SigAlgorithm="RSA 256",
+        Valid_From=date.fromisoformat("2023-01-01"),
+        Valid_To=date.fromisoformat("2023-01-02"),
+        Last_Check=datetime.fromisoformat("2023-01-03 00:00:00"),
+        CertSerial="012345",
+    )
+    inserted = update(*data.values())
+    after = table.find_one(Domain="slack.com")
+    assert [v for v in inserted.values()] == [*data.values()]
+    assert all([v == after[k] for k, v in data.items()])
+
+
+def update_v1(db_v1, domain, subject, issuer, sig_algo, start_date, expiry_date, checkdate):
+    data = dict(
+        Domain=domain,
+        Subject=subject,
+        Issuer=issuer,
+        SigAlgorithm=sig_algo,
+        Valid_From=start_date,
+        Valid_To=expiry_date,
+        Last_Check=checkdate,
+    )
+    with db_v1 as tx:
+        certificates = tx["Certificates"]
+        certificates.update(data, ["Domain"])
+    return data
+
+
+def test_info(cli: click.Group):
+    result: Result = CliRunner().invoke(cli=cli, args=['info'])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == os.environ["DATABASE"]
+
+
+def test_list(cli: click.Group):
+    result: Result = CliRunner().invoke(cli=cli, args=['list'])
+    assert result.exit_code == 0
+    output = result.stdout.splitlines()
+    assert len(output) == 4
+
+
+def test_show(cli: click.Group):
+    result: Result = CliRunner().invoke(cli=cli, args=['show', 'github.com'])
+    assert result.exit_code == 0
+    output = result.stdout.splitlines()
+    assert len(output) == 1

--- a/scanner/migration_tests/migration_test.py
+++ b/scanner/migration_tests/migration_test.py
@@ -69,6 +69,7 @@ def table(table_v1: dataset.Table):
         Valid_To=date.fromisoformat("2023-01-02"),
         Last_Check=datetime.fromisoformat("2023-01-03 00:00:00"),
         CertSerial=None,
+        PeerAddress=None
     )
     migrated_data = table.find_one(Domain="github.com")
     assert all([v == migrated_data[k] for k, v in check_data.items()])
@@ -93,6 +94,7 @@ def test_update_s1(table: dataset.Table):
         Valid_To=date.fromisoformat("2023-01-02"),
         Last_Check=datetime.fromisoformat("2023-01-03 00:00:00"),
         CertSerial="012345",
+        PeerAddress="192.168.1.1:443"
     )
     inserted = update(*data.values())
     after = table.find_one(Domain="slack.com")

--- a/scanner/ssl_certificate_checker.py
+++ b/scanner/ssl_certificate_checker.py
@@ -1,15 +1,13 @@
 from datetime import datetime
-# import pyopenssl
 import ssl
 import OpenSSL
 import sys
-# from cryptography import x509
-# from cryptography.hazmat.backends import default_backend
+import ssl_patch
 
 
 def scan(url):
     try:
-        cert_data = ssl.get_server_certificate((url, 443), ssl_version=ssl.PROTOCOL_SSLv23, timeout=10)
+        cert_data, peername = ssl_patch.get_server_certificate_ex((url, 443), ssl_version=ssl.PROTOCOL_SSLv23, timeout=10)
     except ssl.SSLError as e:
         print(f'Failed to resolve hostname [{url}]: {e}')
         return (None)
@@ -55,7 +53,10 @@ def scan(url):
     checkdate = now.replace(microsecond=0)
     print('Checkdate:', checkdate)
 
-    return (subject, issuer, sig_algo, start_date, expiry_date, checkdate, cert_serial)
+    peer_address = f"{peername[0]}:{peername[1]}"
+    print('PeerAddress:', peer_address)
+
+    return (subject, issuer, sig_algo, start_date, expiry_date, checkdate, cert_serial, peer_address)
 
 
 if __name__ == "__main__":

--- a/scanner/ssl_certificate_checker.py
+++ b/scanner/ssl_certificate_checker.py
@@ -42,6 +42,10 @@ def scan(url):
     sig_algo = x509.get_signature_algorithm().decode()
     print('Algorithm:', sig_algo)
 
+    # CertSerial
+    cert_serial = '{0:x}'.format(int(x509.get_serial_number()))
+    print('Serial:', cert_serial)
+
     # Other information
     # components = x509.get_subject().get_components()
     # for component in components:
@@ -51,7 +55,7 @@ def scan(url):
     checkdate = now.replace(microsecond=0)
     print('Checkdate:', checkdate)
 
-    return (subject, issuer, sig_algo, start_date, expiry_date, checkdate)
+    return (subject, issuer, sig_algo, start_date, expiry_date, checkdate, cert_serial)
 
 
 if __name__ == "__main__":

--- a/scanner/ssl_patch.py
+++ b/scanner/ssl_patch.py
@@ -1,0 +1,25 @@
+"""
+This code is copied and modified from CPyhon 3.10
+https://github.com/python/cpython/blob/v3.10.11/Lib/ssl.py
+
+The LICENSE of this code is available at the following address
+https://github.com/python/cpython/blob/v3.10.11/LICENSE
+
+"""
+
+import ssl
+import socket
+
+
+def get_server_certificate_ex(addr: tuple[str, int], ssl_version: int = ssl.PROTOCOL_TLS, timeout=10) -> tuple[str, tuple[str, int]]:
+    """Retrieve the certificate from the server at the specified address,
+    and return it as a PEM-encoded string.
+    If 'ca_certs' is specified, validate the server cert against it.
+    If 'ssl_version' is specified, use it in the connection attempt."""
+    host, port = addr
+    context = ssl._create_unverified_context(ssl_version)
+    with socket.create_connection(addr, timeout=timeout) as sock:
+        peername = sock.getpeername()
+        with context.wrap_socket(sock, server_hostname=host) as sslsock:
+            dercert = sslsock.getpeercert(True)
+    return ssl.DER_cert_to_PEM_cert(dercert), peername

--- a/scanner/tests/cli_test.py
+++ b/scanner/tests/cli_test.py
@@ -10,13 +10,13 @@ os.environ["SQLALCHEMY_SILENCE_UBER_WARNING"] = "1"
 import dataset  # noqa: E402
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def db():
     from db import db
     return db
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def table(db: dataset.Database):
     from db import create_certificates_table, populate_certificates_table
     table = create_certificates_table(drop_exists=True)
@@ -29,7 +29,7 @@ def table(db: dataset.Database):
     return table
 
 
-@pytest.fixture(name='cli')
+@pytest.fixture(name='cli', scope="module")
 def cli(db: dataset.Database) -> click.Group:
     from command import cli as cli_application
     return cli_application

--- a/scanner/tests/scanner_test.py
+++ b/scanner/tests/scanner_test.py
@@ -77,6 +77,7 @@ def test_update_s1(table: dataset.Table):
         None,
         None,
         None,
+        None,
     ]
     assert [v for v in before.values()] == default_data
     data = [
@@ -88,6 +89,7 @@ def test_update_s1(table: dataset.Table):
         date.fromisoformat("2023-01-02"),
         datetime.fromisoformat("2023-01-03 00:00:00"),
         "0123456789",
+        "192.168.1.1:443",
     ]
     inserted = update(*data)
     after = table.find_one(Domain="github.com")

--- a/scanner/tests/scanner_test.py
+++ b/scanner/tests/scanner_test.py
@@ -10,7 +10,7 @@ from db import create_certificates_table, populate_certificates_table  # noqa:E4
 from controler import get_record_count, get_record_chunk, get_list, update  # noqa:E402
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def table():
     table = create_certificates_table(drop_exists=True)
     print(table)
@@ -76,6 +76,7 @@ def test_update_s1(table: dataset.Table):
         None,
         None,
         None,
+        None,
     ]
     assert [v for v in before.values()] == default_data
     data = [
@@ -86,6 +87,7 @@ def test_update_s1(table: dataset.Table):
         date.fromisoformat("2023-01-01"),
         date.fromisoformat("2023-01-02"),
         datetime.fromisoformat("2023-01-03 00:00:00"),
+        "0123456789",
     ]
     inserted = update(*data)
     after = table.find_one(Domain="github.com")


### PR DESCRIPTION
WIP: https://github.com/mahiroaug/ssl_scanner/issues/14 , https://github.com/mahiroaug/ssl_scanner/issues/16

Add a new column 'CertSerial' and 'PeerAddress' to the database table.

- The scanners will store the certificate serial numbers of the domains.
- The scanners will store the remote address and port of the endpoint, from which the certificate retrieved.

This PR does not change the output, except for the results of the 'scan' command.

---

This PR contains 3 groups of commits.

1. Fix the table management code (no effects in functions)
    - https://github.com/mahiroaug/ssl_scanner/compare/339528f...eb74abe
2. WIP #14
    - 'CertSerial' column added, scanner's functions added, and DB migration tests from previous schema.
    - https://github.com/mahiroaug/ssl_scanner/compare/eb74abe9e396769f42c4791031d34ac4b98ca024...a33ca0554521e5baff276c70d077b3f3585d3266
 2. WIP #16
    - 'PeerAddress' column added, scanner's functions added.
    - https://github.com/mahiroaug/ssl_scanner/compare/a33ca0554521e5baff276c70d077b3f3585d3266...e821356d06879d671de17c310fc64948841efbca
